### PR TITLE
feat: always output parser errors

### DIFF
--- a/cbn_cli.py
+++ b/cbn_cli.py
@@ -360,13 +360,11 @@ def call_validate_cbn_parser(args, config_file_path, log_file_path):
     output_results.append(results)
     for result in results:
       print(result)
-  else:
-    errors = result_response.get('errors')
-    if errors:
-      for err in errors:
-        print(err['errorMsg'])
-        print('on log entry')
-        print(type(err['logEntry']))
+  errors = result_response.get('errors')
+  if errors:
+    for err in errors:
+      print(err['errorMsg'])
+      print(type(err['logEntry']))
   return output_results
 
 

--- a/cbn_cli.py
+++ b/cbn_cli.py
@@ -364,7 +364,7 @@ def call_validate_cbn_parser(args, config_file_path, log_file_path):
   if errors:
     for err in errors:
       print(err['errorMsg'])
-      print(type(err['logEntry']))
+      print(err['logEntry'])
   return output_results
 
 


### PR DESCRIPTION
By having the errors output behind an else statement it can hide errors when looking at log batch sizes of 10, 1k etc.