### PR TITLE
Support for Windows/non unix homepath call & main call

### DIFF
--- a/cbn_cli.py
+++ b/cbn_cli.py
@@ -34,8 +34,8 @@ from google.oauth2 import service_account
 from googleapiclient import _auth
 
 AUTHORIZATION_SCOPES = ['https://www.googleapis.com/auth/chronicle-backstory']
-DEFAULT_CREDS_FILE_PATH = os.path.join(os.environ['HOME'],
-                                       '.chronicle_credentials.json')
+DEFAULT_CREDS_FILE_PATH = os.path.join(os.path.expanduser('~'),
+                                       'chronicle_credentials.json')
 
 # URLs for Chronicle CBN API endpoints.
 CHRONICLE_API_V1_URL = 'https://backstory.googleapis.com/v1'
@@ -557,4 +557,13 @@ def main(input_args):
 
 
 if __name__ == '__main__':
-  main(sys.argv[1:])
+  try:
+    main(sys.argv[1:])
+  except AttributeError:
+    time.sleep(1)
+    print(f"The command was incorrect or did not contain a function to run. Please see \"help\" by running the command \"python cbn_cli.py --help\"\n\n\n")
+    time.sleep(1)
+    if len(sys.argv) == 1:
+      parser = arg_parser()
+      parser.print_help()
+      sys.exit(1)


### PR DESCRIPTION
I updated the os.environ['HOME'] for os.path.expanduser to support windows homeopath for users that do not specify credential file path.
 I also updated the main func call to catch attribute error when user test the script with just python cbn_cli.py